### PR TITLE
fix(subscribers): handle empty 200 response from AWeber move endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2026-03-30
+
+### Added
+
+- `enforce_custom_field_mapping` optional field on `AWeberMoveSubscriberDto`. When `true`, AWeber maps custom fields by name during a move instead of by position, avoiding misalignment when source and destination lists order fields differently.
+
+### Changed
+
+- **`SubscribersService.moveSubscriber`** return type is `Promise<AWeberSubscriber | null>`. The previous public contract used `AWeberMoveSubscriberResponse` (`{ self_link }` only), then briefly `AWeberSubscriber`. Successful moves typically return `200` with an **empty body** — that case resolves to `null` instead of throwing.
+- **`moveSubscriber` HTTP request** uses `application/x-www-form-urlencoded` and `URLSearchParams` for the body, matching AWeber’s documented move operation. JSON bodies were accepted for basic moves but **`enforce_custom_field_mapping` was ignored**.
+
+### Removed
+
+- **`AWeberMoveSubscriberResponse`** — removed from `subscribers.types.ts` and from public exports in `src/index.ts`. Use `AWeberSubscriber | null` with `moveSubscriber`.
+
+### Fixed
+
+- Successful subscriber moves no longer throw `Move Subscriber API Call returned empty response` when AWeber returns an empty success body.
+- Custom field mapping option is applied correctly when sent as form-encoded data.
+
+### Migration
+
+1. Treat `null` from `moveSubscriber` as a normal success when you only need to confirm the move; fetch the subscriber on the destination list (e.g. by email) if you need the full record.
+2. Remove any imports of `AWeberMoveSubscriberResponse`; type results as `AWeberSubscriber | null`.
+3. For moves between lists with custom fields, pass `enforce_custom_field_mapping: true` in the DTO.
+
+See also the **Migration** section in [README.md](./README.md).
+
+[Unreleased]: https://github.com/juicyllama/nestjs-aweber/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/juicyllama/nestjs-aweber/compare/v0.12.8...v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 ### Changed
 
 - **`SubscribersService.moveSubscriber`** return type is `Promise<AWeberSubscriber | null>`. The previous public contract used `AWeberMoveSubscriberResponse` (`{ self_link }` only), then briefly `AWeberSubscriber`. Successful moves typically return `200` with an **empty body** — that case resolves to `null` instead of throwing.
-- **`moveSubscriber` HTTP request** uses `application/x-www-form-urlencoded` and `URLSearchParams` for the body, matching AWeber’s documented move operation. JSON bodies were accepted for basic moves but **`enforce_custom_field_mapping` was ignored**.
+- **`moveSubscriber` HTTP request** uses `application/x-www-form-urlencoded` and `URLSearchParams` for the body, matching AWeber’s documented move operation. Previous versions accepted JSON bodies for basic moves but **`enforce_custom_field_mapping` was ignored** on those requests.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -134,9 +134,13 @@ We recommend using Redis which ships out of the box, provide your redis environm
 REDIS_URI=redis://localhost:6379
 ```
 
+## Changelog
+
+Release history and semver notes: **[CHANGELOG.md](./CHANGELOG.md)** (also published with the package on npm).
+
 ## Migration
 
-### v0.13.0 (Breaking Changes)
+### v1.0.0 (Breaking Changes)
 
 **`moveSubscriber` return type changed**
 

--- a/README.md
+++ b/README.md
@@ -149,14 +149,17 @@ Release history and semver notes: **[CHANGELOG.md](./CHANGELOG.md)** (also publi
 AWeber's move endpoint returns `200 OK` with an empty body on success. Previously this threw an error; now it returns `null`. Consumers must handle the nullable return:
 
 ```typescript
+const sourceSubscriber = await subscribersService.getSubscriber(accountId, listId, subscriberId)
+const subscriberEmail = sourceSubscriber.email
+
 const result = await subscribersService.moveSubscriber(accountId, listId, subscriberId, {
   list_id: destinationListId,
   enforce_custom_field_mapping: true,
 })
 
 if (!result) {
-  // Normal success — subscriber moved, poll destination list if you need the new record
-  const moved = await subscribersService.getSubscriberByEmail(accountId, destinationListId, email)
+  // Normal success — subscriber moved; fetch on destination list if you need the full record
+  const moved = await subscribersService.getSubscriberByEmail(accountId, destinationListId, subscriberEmail)
 }
 ```
 
@@ -166,7 +169,7 @@ This type (`{ self_link: string }`) has been removed from exports. Use `AWeberSu
 
 **`enforce_custom_field_mapping` added to `AWeberMoveSubscriberDto`**
 
-New optional boolean field. When `true`, custom fields are mapped by name rather than by position during a move, preventing data loss when source and destination lists have fields in a different order. Recommended for all move operations.
+New optional boolean on `AWeberMoveSubscriberDto`. Set `enforce_custom_field_mapping` to `true` when the source and destination lists have custom fields in a different order or with different names, so AWeber maps by name and avoids misalignment; you can also enable it as a general safeguard for complex moves with many custom fields.
 
 ## Types
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,36 @@ We recommend using Redis which ships out of the box, provide your redis environm
 REDIS_URI=redis://localhost:6379
 ```
 
+## Migration
+
+### v0.13.0 (Breaking Changes)
+
+**`moveSubscriber` return type changed**
+
+`SubscribersService.moveSubscriber()` now returns `Promise<AWeberSubscriber | null>` instead of `Promise<AWeberSubscriber>`.
+
+AWeber's move endpoint returns `200 OK` with an empty body on success. Previously this threw an error; now it returns `null`. Consumers must handle the nullable return:
+
+```typescript
+const result = await subscribersService.moveSubscriber(accountId, listId, subscriberId, {
+  list_id: destinationListId,
+  enforce_custom_field_mapping: true,
+})
+
+if (!result) {
+  // Normal success — subscriber moved, poll destination list if you need the new record
+  const moved = await subscribersService.getSubscriberByEmail(accountId, destinationListId, email)
+}
+```
+
+**`AWeberMoveSubscriberResponse` type removed**
+
+This type (`{ self_link: string }`) has been removed from exports. Use `AWeberSubscriber | null` instead.
+
+**`enforce_custom_field_mapping` added to `AWeberMoveSubscriberDto`**
+
+New optional boolean field. When `true`, custom fields are mapped by name rather than by position during a move, preventing data loss when source and destination lists have fields in a different order. Recommended for all move operations.
+
 ## Types
 
 We have typed each AWeber Resource type and have exported them for your use. 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@juicyllama/nestjs-aweber",
-    "version": "0.12.8",
+    "version": "0.13.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@juicyllama/nestjs-aweber",
-            "version": "0.12.8",
+            "version": "0.13.0",
             "license": "0BSD",
             "devDependencies": {
                 "@eslint/eslintrc": "^3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@juicyllama/nestjs-aweber",
-    "version": "0.13.0",
+    "version": "1.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@juicyllama/nestjs-aweber",
-            "version": "0.13.0",
+            "version": "1.0.0",
             "license": "0BSD",
             "devDependencies": {
                 "@eslint/eslintrc": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@juicyllama/nestjs-aweber",
-    "version": "0.13.0",
+    "version": "1.0.0",
     "description": "A NestJS app for integrating with AWeber API",
     "publishConfig": {
         "access": "public",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@juicyllama/nestjs-aweber",
-    "version": "0.12.8",
+    "version": "0.13.0",
     "description": "A NestJS app for integrating with AWeber API",
     "publishConfig": {
         "access": "public",

--- a/src/aweber/subscribers/subscribers.mocks.ts
+++ b/src/aweber/subscribers/subscribers.mocks.ts
@@ -53,12 +53,8 @@ export const createSubscriberMock: AWeberSubscriber = {
 	self_link: 'https://api.aweber.com/1.0/accounts/123/lists/456/subscribers/790',
 }
 
-// AWeber assigns a new subscriber ID on the destination list, hence id differs from the source
-export const moveSubscriberMock: AWeberSubscriber = {
-	...subscriberMock,
-	id: 790,
-	self_link: 'https://api.aweber.com/1.0/accounts/123/lists/789/subscribers/790',
-}
+// AWeber returns 200 with an empty body on a successful move, so null is the realistic mock
+export const moveSubscriberMock: AWeberSubscriber | null = null
 
 export const createPurchaseMock = {
 	message: 'Purchase event created successfully',

--- a/src/aweber/subscribers/subscribers.service.ts
+++ b/src/aweber/subscribers/subscribers.service.ts
@@ -298,6 +298,7 @@ export class SubscribersService {
 	/**
 	 * Move subscriber to another list.
 	 * Uses AWeber's ws.op=move operation which preserves name, custom_fields, tags, and other data.
+	 * Returns null when AWeber responds with 200 and an empty body (the normal success case).
 	 * @see https://api.aweber.com/#tag/Subscribers/paths/~1accounts~1{accountId}~1lists~1{listId}~1subscribers~1{subscriberId}/post
 	 */
 	async moveSubscriber(
@@ -305,7 +306,7 @@ export class SubscribersService {
 		listId: number,
 		subscriberId: number,
 		data: AWeberMoveSubscriberDto,
-	): Promise<AWeberSubscriber> {
+	): Promise<AWeberSubscriber | null> {
 		if (process.env.NODE_ENV === 'test') {
 			return moveSubscriberMock
 		}
@@ -338,7 +339,21 @@ export class SubscribersService {
 			body: JSON.stringify(body),
 		})
 
-		return await safeJsonParse<AWeberSubscriber>(response, 'Move Subscriber API Call')
+		if (!response.ok) {
+			const errorText = await response.text()
+			throw new Error(`Move Subscriber API Call failed: ${response.status} - ${errorText}`)
+		}
+
+		const responseText = await response.text()
+		if (!responseText.trim()) {
+			return null
+		}
+
+		try {
+			return JSON.parse(responseText) as AWeberSubscriber
+		} catch {
+			throw new Error(`Move Subscriber API Call returned invalid JSON: ${responseText}`)
+		}
 	}
 
 	/**

--- a/src/aweber/subscribers/subscribers.service.ts
+++ b/src/aweber/subscribers/subscribers.service.ts
@@ -334,9 +334,9 @@ export class SubscribersService {
 			method: 'POST',
 			headers: {
 				Authorization: `Bearer ${accessToken}`,
-				'Content-Type': 'application/json',
+				'Content-Type': 'application/x-www-form-urlencoded',
 			},
-			body: JSON.stringify(body),
+			body: new URLSearchParams(body).toString(),
 		})
 
 		if (!response.ok) {

--- a/src/aweber/subscribers/subscribers.test.spec.ts
+++ b/src/aweber/subscribers/subscribers.test.spec.ts
@@ -118,21 +118,14 @@ describe('Subscribers', () => {
 	})
 
 	describe('Move Subscriber', () => {
-		it('should move a subscriber to another list preserving all data', async () => {
+		it('should return null on a successful move (AWeber returns 200 with empty body)', async () => {
 			const moveData: AWeberMoveSubscriberDto = {
 				list_id: 789,
 				last_followup_message_number_sent: '0',
 			}
 
 			const result = await subscribersService.moveSubscriber(123, 456, 789, moveData)
-			expect(result).toBeDefined()
-			expect(result.id).toBe(790)
-			expect(result.email).toBe('user@example.com')
-			expect(result.self_link).toContain('/lists/789/subscribers/790')
-			expect(result.custom_fields).toEqual({ apple: 'fuji', pear: 'bosc' })
-			expect(result.tags).toEqual(['slow', 'fast', 'lightspeed'])
-			expect(result.name).toBe('John Doe')
-			expect(result.status).toBe('subscribed')
+			expect(result).toBeNull()
 		})
 	})
 

--- a/src/aweber/subscribers/subscribers.test.spec.ts
+++ b/src/aweber/subscribers/subscribers.test.spec.ts
@@ -129,6 +129,67 @@ describe('Subscribers', () => {
 		})
 	})
 
+	describe('Move Subscriber Response Parsing', () => {
+		const originalNodeEnv = process.env.NODE_ENV
+		const moveData: AWeberMoveSubscriberDto = {
+			list_id: 789,
+			last_followup_message_number_sent: '0',
+		}
+
+		beforeEach(() => {
+			process.env.NODE_ENV = 'development'
+			jest.spyOn(subscribersService['authService'], 'accessToken').mockResolvedValue('fake-token')
+		})
+
+		afterEach(() => {
+			process.env.NODE_ENV = originalNodeEnv
+			jest.restoreAllMocks()
+		})
+
+		it('should return null when response is 200 with empty body', async () => {
+			jest.spyOn(global, 'fetch').mockResolvedValue({
+				ok: true,
+				text: () => Promise.resolve(''),
+			} as Response)
+
+			const result = await subscribersService.moveSubscriber(123, 456, 789, moveData)
+			expect(result).toBeNull()
+		})
+
+		it('should return parsed subscriber when response is 200 with valid JSON', async () => {
+			const subscriberPayload = {
+				id: 790,
+				email: 'user@example.com',
+				is_verified: true,
+				resource_type_link: 'https://api.aweber.com/1.0/#subscriber',
+				self_link: 'https://api.aweber.com/1.0/accounts/123/lists/789/subscribers/790',
+				status: 'subscribed',
+				subscribed_at: '2025-01-01T00:00:00-05:00',
+				subscription_method: 'api',
+				tags: ['test'],
+			}
+
+			jest.spyOn(global, 'fetch').mockResolvedValue({
+				ok: true,
+				text: () => Promise.resolve(JSON.stringify(subscriberPayload)),
+			} as Response)
+
+			const result = await subscribersService.moveSubscriber(123, 456, 789, moveData)
+			expect(result).toEqual(subscriberPayload)
+		})
+
+		it('should throw when response is 200 with invalid JSON', async () => {
+			jest.spyOn(global, 'fetch').mockResolvedValue({
+				ok: true,
+				text: () => Promise.resolve('not valid json{{{'),
+			} as Response)
+
+			await expect(subscribersService.moveSubscriber(123, 456, 789, moveData)).rejects.toThrow(
+				'Move Subscriber API Call returned invalid JSON',
+			)
+		})
+	})
+
 	describe('Create Purchase', () => {
 		it('should create a purchase event for a subscriber', async () => {
 			const purchaseData: AWeberCreatePurchaseDto = {


### PR DESCRIPTION
 - moveSubscriber now returns null when AWeber responds with empty body
 - bypass safeJsonParse in favour of explicit response handling
 - update mock to return null matching real API behaviour
 - update test to assert null return on successful move

Refs: HBDV-1643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Move operation now treats a successful empty response as "no returned subscriber", improves request encoding and surfaces clearer errors for failed/invalid responses.
* **Tests**
  * Expanded tests to cover empty, valid, and invalid move responses and related parsing/error paths.
* **Documentation**
  * Changelog and migration notes added; documents nullable move results and a new option to control custom-field mapping.
* **Chores**
  * Package version bumped to v1.0.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->